### PR TITLE
Add cmake to setup.sh

### DIFF
--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -2,7 +2,7 @@
 
 # Dependencies
 apt update
-apt install -y python3 pip git curl wget nano sudo apt-utils
+apt install -y python3 pip git cmake curl wget nano sudo apt-utils
 
 # Clone only the corresponding branch
 # This way, the Docker tag is the same (if done correctly manually) as the branch inside it


### PR DESCRIPTION
In my test of the Dockerfile the install.sh script failed due to missing cmake. Installing it through apt in setup.sh fixed it.